### PR TITLE
Show confirmation dialog before publish

### DIFF
--- a/bookmarklets/maio/maio-remote.js
+++ b/bookmarklets/maio/maio-remote.js
@@ -615,6 +615,70 @@
 
   }
 
+  function addHiddenDialogTrigger(button) {
+    if(!button) {
+      return;
+    }
+
+    const dialogTrigger = document.createElement("button");
+    dialogTrigger.addEventListener("click", (e) => {
+      e.preventDefault();
+      
+      const shouldProceed = window.confirm("Are you sure you want to publish?");
+      
+      if(!shouldProceed) {
+        return;
+      }
+      
+      button.click();
+    })
+    
+    dialogTrigger.classList.add("maio-hidden-dialog-trigger")
+    dialogTrigger.setAttribute("style", "position: absolute; inset: 0; z-index: 1; opacity: 0");
+    
+    button.parentElement.style.position = "relative";
+    button.insertAdjacentElement("afterend", dialogTrigger)
+  }
+
+  function hasHiddenDialogTrigger(button) {
+    return button instanceof HTMLElement && button.parentElement?.querySelector(".maio-hidden-dialog-trigger")
+  }
+
+  function addDialogBeforePublish() {
+    const helixSidekick = document.querySelector("helix-sidekick");
+
+    if(!helixSidekick?.shadowRoot) {
+      return;
+    }
+    
+    const sidekickObserver = new MutationObserver(() => {
+      const publishButton = helixSidekick.shadowRoot.querySelector(".publish button");
+
+      if(publishButton && !hasHiddenDialogTrigger(publishButton)) {
+        addHiddenDialogTrigger(publishButton);
+        sidekickObserver.disconnect();
+      }
+    })
+
+    sidekickObserver.observe(helixSidekick.shadowRoot, {
+      childList: true,
+      subtree: true,
+    })
+
+    const preflightObserver = new MutationObserver(() => {
+      const publishButton = document.querySelector(".preflight #publish-action button.preflight-action");
+
+      if(publishButton && !hasHiddenDialogTrigger(publishButton)) {
+        addHiddenDialogTrigger(publishButton);
+      }
+    })
+
+    preflightObserver.observe(document.body, {
+      childList: true,
+      subtree: true
+    })
+  }
+
   let checkMaio = function() {
       if (document.querySelector('#maioFooter')) {
           return true;
@@ -642,6 +706,7 @@
                   addDocOpener();
                   addMiloBlockInfo();
                   addOpenLangstore();
+                  addDialogBeforePublish();
               }, 1000);
 
 


### PR DESCRIPTION
## Summary

Added a function to add invisible buttons on top of publish buttons (in sidekick bar and preflight modal), which triggers a confirmation dialog on click.

![image](https://github.com/plimadobe/plim/assets/55642841/c04761e9-eacd-4397-a01f-42c4e4561798)

## URL

- https://add-dialog-before-publishing--plim--yurikoshiishi.hlx.page/bookmarklets/maio/maio-remote.js